### PR TITLE
Label sync: use empty string default for delete

### DIFF
--- a/src/cli.php
+++ b/src/cli.php
@@ -52,7 +52,7 @@ try {
 
     switch ($args->getCommand()) {
         case 'labels':
-            $sync->syncLabels($args->getOpt('delete'));
+            $sync->syncLabels($args->getOpt('delete', ''));
             break;
         case 'milestones':
             $sync->syncMilestones($args->getOpt('status', 'open'), $args->getOpt('autoclose', false));


### PR DESCRIPTION
Closes #3 

Since the `delete` parameter is defined as a string, it would make sense for `getOpt()` to pass an empty string as the default. 

I'm still not convinced the "delete if you get anything but empty string" condition is a good idea in `syncLabels()` since the next use of it is just as likely to create the same issue, but this addresses the issue while passing the intended data type.