### PR TITLE
Sort milestones by due_on desc

### DIFF
--- a/src/GithubSync.php
+++ b/src/GithubSync.php
@@ -398,7 +398,7 @@ class GithubSync {
      * @return array[array] Returns an array of milestones.
      */
     public function getMilestones($repo, $state = 'open') {
-        $r = $this->api()->get("/repos/$repo/milestones", ['state' => $state]);
+        $r = $this->api()->get("/repos/$repo/milestones", ['state' => $state, 'direction' => 'desc']);
         $data = array_change_key_case(array_column($r->getBody(), null, 'title'));
         return $data;
     }


### PR DESCRIPTION
This will let us consistently operate on milestones we actually care about (ones with the most proximate due date). Fixes #5.